### PR TITLE
Changes for python3

### DIFF
--- a/test/__main__.py
+++ b/test/__main__.py
@@ -2,9 +2,9 @@ from testing.fun import *
 from testing.work import *
 
 try:
-    print open('.SELF/README.md').read()
+    print (open('.SELF/README.md').read())
 except (IOError, OSError):
-    print "Rats, no README"
+    print ("Rats, no README")
 
-print Fun()
-print Work()
+print (Fun())
+print (Work())


### PR DESCRIPTION
Modern systems have /usr/bin/python pointing to python3 instead of
python2, so breeder must work with python3 as well.

python3 requires bytes for base64 encoding and decoding and for zlib
compression. To simplify things, open the file as binary for compressed
or binary snake, text otherwise.

The result of base64 has to be converted back to text. This is different
for python2 and python3, so use a version-dependent function d() for
this. Since the result of base64 is pure ascii, we can use the ascii
codec for this conversion.


breed_gtk_image wasn't tested but it looks OK.